### PR TITLE
Add Suna AI integration module

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+DAYTONA_API_KEY=your_key_here
+SUPABASE_URL=your_url_here
+OPENAI_API_KEY=your_key_here
+ANTHROPIC_API_KEY=your_key_here

--- a/addons/suna_integration/__init__.py
+++ b/addons/suna_integration/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/addons/suna_integration/__manifest__.py
+++ b/addons/suna_integration/__manifest__.py
@@ -1,0 +1,26 @@
+{
+    'name': 'Suna AI Integration',
+    'version': '1.0',
+    'category': 'Tools',
+    'summary': 'Integrate Suna AI generalist agent into Odoo',
+    'description': """
+        Integrate the Suna AI agent platform into Odoo using an iframe.
+    """,
+    'author': 'Dux Vitae Capital',
+    'website': 'https://www.duxvitaecapital.com',
+    'depends': ['base', 'web'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/suna_iframe_views.xml',
+        'views/suna_menu.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'suna_integration/static/src/js/suna_iframe.js',
+            'suna_integration/static/src/css/suna_iframe.css',
+        ],
+    },
+    'installable': True,
+    'application': True,
+    'auto_install': False,
+}

--- a/addons/suna_integration/controllers/__init__.py
+++ b/addons/suna_integration/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/addons/suna_integration/controllers/main.py
+++ b/addons/suna_integration/controllers/main.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from odoo import http
+from odoo.http import request
+
+
+@http.route('/suna/config', type='json', auth='user')
+def get_suna_config(self):
+    """Return Suna AI configuration for the current user."""
+    return {
+        'suna_url': 'http://localhost:3001',
+        'user_name': request.env.user.name,
+        'user_email': request.env.user.email,
+        'user_id': request.env.user.id,
+    }

--- a/addons/suna_integration/security/ir.model.access.csv
+++ b/addons/suna_integration/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/addons/suna_integration/static/src/css/suna_iframe.css
+++ b/addons/suna_integration/static/src/css/suna_iframe.css
@@ -1,0 +1,41 @@
+.o_suna_iframe_container {
+    height: calc(100vh - 50px);
+    width: 100%;
+    position: relative;
+    background-color: #f5f5f5;
+}
+
+.o_suna_iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    background-color: white;
+}
+
+.o_suna_loading {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: #666;
+}
+
+.o_suna_loading i {
+    color: #42b983;
+    margin-bottom: 10px;
+}
+
+.o_suna_loading p {
+    margin-top: 10px;
+    font-size: 16px;
+}
+
+.o_action_manager .o_suna_iframe_container {
+    height: calc(100vh - 46px);
+}
+
+.o_content .o_suna_iframe_container {
+    padding: 0;
+    margin: 0;
+}

--- a/addons/suna_integration/static/src/js/suna_iframe.js
+++ b/addons/suna_integration/static/src/js/suna_iframe.js
@@ -1,0 +1,75 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { Component, xml, onWillStart, useState } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+class SunaIframe extends Component {
+    static template = xml`
+        <div class="o_suna_iframe_container">
+            <div t-if="state.loading" class="o_suna_loading">
+                <i class="fa fa-spinner fa-spin fa-3x"/>
+                <p>Loading Suna AI...</p>
+            </div>
+            <iframe
+                t-att-src="sunaUrl"
+                class="o_suna_iframe"
+                sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-downloads allow-storage-access-by-user-activation"
+                t-on-load="onIframeLoad"
+                t-on-error="onIframeError"
+            />
+        </div>
+    `;
+
+    setup() {
+        this.rpc = useService("rpc");
+        this.notification = useService("notification");
+        this.state = useState({
+            loading: true,
+            error: false
+        });
+
+        // Default Suna URL
+        this.sunaUrl = "http://localhost:3001";
+
+        onWillStart(async () => {
+            await this.loadSunaConfig();
+        });
+    }
+
+    async loadSunaConfig() {
+        try {
+            const config = await this.rpc("/suna/config", {});
+            if (config.suna_url) {
+                this.sunaUrl = config.suna_url;
+            }
+        } catch (error) {
+            console.error("Failed to load Suna configuration:", error);
+            this.notification.add("Failed to load Suna configuration", {
+                type: "warning"
+            });
+        }
+    }
+
+    onIframeLoad() {
+        this.state.loading = false;
+        console.log("Suna iframe loaded successfully");
+
+        window.addEventListener("message", this.handleSunaMessage.bind(this));
+    }
+
+    onIframeError() {
+        this.state.loading = false;
+        this.state.error = true;
+        this.notification.add("Failed to load Suna AI. Please check if the service is running.", {
+            type: "danger"
+        });
+    }
+
+    handleSunaMessage(event) {
+        if (event.origin !== "http://localhost:3001") return;
+        console.log("Message from Suna:", event.data);
+    }
+}
+
+registry.category("actions").add("suna_iframe", SunaIframe);

--- a/addons/suna_integration/views/suna_iframe_views.xml
+++ b/addons/suna_integration/views/suna_iframe_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="action_suna_iframe" model="ir.actions.client">
+        <field name="name">Suna AI</field>
+        <field name="tag">suna_iframe</field>
+        <field name="target">main</field>
+    </record>
+
+    <record id="action_suna_agent" model="ir.actions.client">
+        <field name="name">AI Agent</field>
+        <field name="tag">suna_iframe</field>
+        <field name="target">main</field>
+        <field name="context">{'suna_path': '/agent'}</field>
+    </record>
+
+    <record id="action_suna_research" model="ir.actions.client">
+        <field name="name">Research Assistant</field>
+        <field name="tag">suna_iframe</field>
+        <field name="target">main</field>
+        <field name="context">{'suna_path': '/research'}</field>
+    </record>
+
+    <record id="action_suna_automation" model="ir.actions.client">
+        <field name="name">Task Automation</field>
+        <field name="tag">suna_iframe</field>
+        <field name="target">main</field>
+        <field name="context">{'suna_path': '/automation'}</field>
+    </record>
+</odoo>

--- a/addons/suna_integration/views/suna_menu.xml
+++ b/addons/suna_integration/views/suna_menu.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="menu_suna_root"
+              name="Suna AI"
+              sequence="52"
+              web_icon="suna_integration,static/description/icon.png"/>
+
+    <menuitem id="menu_suna_agent"
+              name="AI Agent"
+              parent="menu_suna_root"
+              action="action_suna_agent"
+              sequence="10"/>
+
+    <menuitem id="menu_suna_research"
+              name="Research Assistant"
+              parent="menu_suna_root"
+              action="action_suna_research"
+              sequence="20"/>
+
+    <menuitem id="menu_suna_automation"
+              name="Task Automation"
+              parent="menu_suna_root"
+              action="action_suna_automation"
+              sequence="30"/>
+</odoo>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,18 @@ services:
     networks:
       - odoo-postiz-network
 
+  suna:
+    image: ghcr.io/kortix-ai/suna/suna-backend:latest
+    ports:
+      - "3001:3000"
+    environment:
+      - DAYTONA_API_KEY=${DAYTONA_API_KEY}
+      - SUPABASE_URL=${SUPABASE_URL}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    networks:
+      - odoo-postiz-network
+
 volumes:
   odoo-db:
   postiz-db:


### PR DESCRIPTION
## Summary
- add Suna AI integration module following existing iframe modules
- expose `/suna/config` route and iframe JS/CSS
- add Suna AI menus and actions
- update docker-compose with `suna` service
- provide `.env` template for API keys

## Testing
- `python3 -m py_compile addons/suna_integration/controllers/main.py addons/suna_integration/__init__.py addons/suna_integration/__manifest__.py`
- `python3 - <<'EOF'
import yaml; print('YAML ok', yaml.safe_load(open('docker-compose.yml').read()) is not None)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688258a52a30832c8265d14920e1d7fe