### PR TITLE
Set Suna integration to open login page

### DIFF
--- a/addons/suna_integration/controllers/main.py
+++ b/addons/suna_integration/controllers/main.py
@@ -7,7 +7,7 @@ from odoo.http import request
 def get_suna_config(self):
     """Return Suna AI configuration for the current user."""
     return {
-        'suna_url': 'http://localhost:3001',
+        'suna_url': 'http://localhost:3002/login',
         'user_name': request.env.user.name,
         'user_email': request.env.user.email,
         'user_id': request.env.user.id,

--- a/addons/suna_integration/static/src/js/suna_iframe.js
+++ b/addons/suna_integration/static/src/js/suna_iframe.js
@@ -30,7 +30,7 @@ class SunaIframe extends Component {
         });
 
         // Default Suna URL
-        this.sunaUrl = "http://localhost:3002";
+        this.sunaUrl = "http://localhost:3002/login";
 
         onWillStart(async () => {
             await this.loadSunaConfig();


### PR DESCRIPTION
## Summary
- direct users to Suna's login page by default

## Testing
- `python3 -m py_compile addons/suna_integration/controllers/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68827a36ad58832cacd91d5895ab6b66