### PR TITLE
Add DUX MACHINA branding overlays

### DIFF
--- a/addons/n8n_integration/static/src/css/n8n_iframe.css
+++ b/addons/n8n_integration/static/src/css/n8n_iframe.css
@@ -41,3 +41,40 @@
     padding: 0;
     margin: 0;
 }
+
+/* DUX MACHINA Branding Overlay for n8n - ADD AT END OF FILE */
+.o_n8n_iframe_container {
+    position: relative !important;
+}
+
+/* Hide n8n logo area with overlay */
+.o_n8n_iframe_container::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 250px;
+    height: 65px;
+    background: #1a1a2e;
+    z-index: 999;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+}
+
+/* Add DUX MACHINA branding */
+.o_n8n_iframe_container::before {
+    content: "\u26A1 DUX MACHINA";
+    position: absolute;
+    top: 18px;
+    left: 25px;
+    color: white;
+    font-weight: 700;
+    font-size: 20px;
+    letter-spacing: 2px;
+    z-index: 1000;
+    text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+}
+
+/* Subtle gradient to blend overlay */
+.o_n8n_iframe {
+    position: relative;
+}

--- a/addons/postiz_integration/__manifest__.py
+++ b/addons/postiz_integration/__manifest__.py
@@ -18,6 +18,7 @@
     'assets': {
         'web.assets_backend': [
             'postiz_integration/static/src/js/postiz_iframe.js',
+            'postiz_integration/static/src/css/postiz_iframe.css',
         ],
     },
     'installable': True,

--- a/addons/postiz_integration/static/src/css/postiz_iframe.css
+++ b/addons/postiz_integration/static/src/css/postiz_iframe.css
@@ -1,0 +1,30 @@
+/* DUX MACHINA Branding Overlay for POSTIZ */
+.o_postiz_iframe_container {
+    position: relative !important;
+}
+
+/* Hide POSTIZ header area */
+.o_postiz_iframe_container::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 300px;
+    height: 70px;
+    background: #1a1a2e;
+    z-index: 999;
+}
+
+/* Add DUX MACHINA branding */
+.o_postiz_iframe_container::before {
+    content: "\u26A1 DUX MACHINA";
+    position: absolute;
+    top: 20px;
+    left: 25px;
+    color: white;
+    font-weight: 700;
+    font-size: 20px;
+    letter-spacing: 2px;
+    z-index: 1000;
+    text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+}

--- a/addons/suna_integration/static/src/css/suna_iframe.css
+++ b/addons/suna_integration/static/src/css/suna_iframe.css
@@ -39,3 +39,35 @@
     padding: 0;
     margin: 0;
 }
+
+/* DUX MACHINA Branding Overlay for Suna - ADD AT END OF FILE */
+.o_suna_iframe_container {
+    position: relative !important;
+}
+
+/* Hide Suna branding area */
+.o_suna_iframe_container::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 280px;
+    height: 65px;
+    background: #1a1a2e;
+    z-index: 999;
+}
+
+/* Add DUX MACHINA branding */
+.o_suna_iframe_container::before {
+    content: "\u26A1 DUX MACHINA";
+    position: absolute;
+    top: 18px;
+    left: 25px;
+    color: white;
+    font-weight: 700;
+    font-size: 20px;
+    letter-spacing: 2px;
+    z-index: 1000;
+    text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+}
+


### PR DESCRIPTION
## Summary
- overlay n8n iframe with DUX MACHINA branding
- create POSTIZ iframe CSS with branding overlay
- show DUX MACHINA overlay on Suna iframe
- register POSTIZ CSS in assets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68830c4f709c832cac75ba9a9a8d9268