### PR TITLE
Fix Matomo iframe blocking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,8 +216,11 @@ services:
       MATOMO_DATABASE_PASSWORD: matomo_secure_password
       MATOMO_DATABASE_DBNAME: matomo
       PHP_MEMORY_LIMIT: 256M
+    command: >
+      bash -c "/usr/local/bin/enable-matomo-iframe.sh && docker-entrypoint.sh apache2-foreground"
     volumes:
       - matomo-data:/var/www/html
+      - ./scripts/enable-matomo-iframe.sh:/usr/local/bin/enable-matomo-iframe.sh:ro
     networks:
       - odoo-postiz-network
 

--- a/scripts/enable-matomo-iframe.sh
+++ b/scripts/enable-matomo-iframe.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+CONFIG="/var/www/html/config/config.ini.php"
+if [ ! -f "$CONFIG" ]; then
+    echo "Matomo config not found at $CONFIG, skipping iframe configuration."
+    exit 0
+fi
+
+if grep -q '^enable_framed_pages' "$CONFIG"; then
+    sed -i 's/^enable_framed_pages *= *.*/enable_framed_pages = 1/' "$CONFIG"
+else
+    echo 'enable_framed_pages = 1' >> "$CONFIG"
+fi
+
+if grep -q '^enable_framed_settings' "$CONFIG"; then
+    sed -i 's/^enable_framed_settings *= *.*/enable_framed_settings = 1/' "$CONFIG"
+else
+    echo 'enable_framed_settings = 1' >> "$CONFIG"
+fi


### PR DESCRIPTION
## Summary
- add a script that modifies Matomo's config to allow iframes
- run the script before starting Matomo via `docker-compose`

## Testing
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885463c2264832ca6483025ee44136b