### PR TITLE
Add Metabase BI integration

### DIFF
--- a/addons/metabase_integration/__init__.py
+++ b/addons/metabase_integration/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/addons/metabase_integration/__manifest__.py
+++ b/addons/metabase_integration/__manifest__.py
@@ -1,0 +1,26 @@
+{
+    'name': 'Metabase Business Intelligence',
+    'version': '1.0',
+    'category': 'Tools',
+    'summary': 'Integrate Metabase business intelligence platform into Odoo via iframe',
+    'description': """
+        This module allows you to access the Metabase dashboards and analytics directly from within Odoo using an iframe integration.
+    """,
+    'author': 'Dux Vitae Capital',
+    'website': 'https://www.duxvitaecapital.com',
+    'depends': ['base', 'web'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/metabase_iframe_views.xml',
+        'views/metabase_menu.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'metabase_integration/static/src/js/metabase_iframe.js',
+            'metabase_integration/static/src/css/metabase_iframe.css',
+        ],
+    },
+    'installable': True,
+    'application': True,
+    'auto_install': False,
+}

--- a/addons/metabase_integration/controllers/__init__.py
+++ b/addons/metabase_integration/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/addons/metabase_integration/controllers/main.py
+++ b/addons/metabase_integration/controllers/main.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from odoo import http
+from odoo.http import request
+
+
+@http.route('/metabase/config', type='json', auth='user')
+def get_metabase_config(self):
+    """Return Metabase configuration for the current user."""
+    return {
+        'metabase_url': 'http://localhost:3030',
+        'user_name': request.env.user.name,
+        'user_email': request.env.user.email,
+        'user_id': request.env.user.id,
+    }

--- a/addons/metabase_integration/security/ir.model.access.csv
+++ b/addons/metabase_integration/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/addons/metabase_integration/static/src/css/metabase_iframe.css
+++ b/addons/metabase_integration/static/src/css/metabase_iframe.css
@@ -1,0 +1,41 @@
+.o_metabase_iframe_container {
+    height: calc(100vh - 50px);
+    width: 100%;
+    position: relative;
+    background-color: #f5f5f5;
+}
+
+.o_metabase_iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    background-color: white;
+}
+
+.o_metabase_loading {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: #666;
+}
+
+.o_metabase_loading i {
+    color: #509EE3;
+    margin-bottom: 10px;
+}
+
+.o_metabase_loading p {
+    margin-top: 10px;
+    font-size: 16px;
+}
+
+.o_action_manager .o_metabase_iframe_container {
+    height: calc(100vh - 46px);
+}
+
+.o_content .o_metabase_iframe_container {
+    padding: 0;
+    margin: 0;
+}

--- a/addons/metabase_integration/static/src/js/metabase_iframe.js
+++ b/addons/metabase_integration/static/src/js/metabase_iframe.js
@@ -1,0 +1,75 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { Component, xml, onWillStart, useState } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+class MetabaseIframe extends Component {
+    static template = xml`
+        <div class="o_metabase_iframe_container">
+            <div t-if="state.loading" class="o_metabase_loading">
+                <i class="fa fa-spinner fa-spin fa-3x"/>
+                <p>Loading Metabase...</p>
+            </div>
+            <iframe
+                t-att-src="metabaseUrl"
+                class="o_metabase_iframe"
+                sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-downloads allow-storage-access-by-user-activation"
+                t-on-load="onIframeLoad"
+                t-on-error="onIframeError"
+            />
+        </div>
+    `;
+
+    setup() {
+        this.rpc = useService("rpc");
+        this.notification = useService("notification");
+        this.state = useState({
+            loading: true,
+            error: false
+        });
+
+        // Default Metabase URL
+        this.metabaseUrl = "http://localhost:3030";
+
+        onWillStart(async () => {
+            await this.loadMetabaseConfig();
+        });
+    }
+
+    async loadMetabaseConfig() {
+        try {
+            const config = await this.rpc("/metabase/config", {});
+            if (config.metabase_url) {
+                this.metabaseUrl = config.metabase_url;
+            }
+        } catch (error) {
+            console.error("Failed to load Metabase configuration:", error);
+            this.notification.add("Failed to load Metabase configuration", {
+                type: "warning"
+            });
+        }
+    }
+
+    onIframeLoad() {
+        this.state.loading = false;
+        console.log("Metabase iframe loaded successfully");
+
+        window.addEventListener("message", this.handleMetabaseMessage.bind(this));
+    }
+
+    onIframeError() {
+        this.state.loading = false;
+        this.state.error = true;
+        this.notification.add("Failed to load Metabase. Please check if the service is running.", {
+            type: "danger"
+        });
+    }
+
+    handleMetabaseMessage(event) {
+        if (event.origin !== "http://localhost:3030") return;
+        console.log("Message from Metabase:", event.data);
+    }
+}
+
+registry.category("actions").add("metabase_iframe", MetabaseIframe);

--- a/addons/metabase_integration/views/metabase_iframe_views.xml
+++ b/addons/metabase_integration/views/metabase_iframe_views.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="action_metabase_iframe" model="ir.actions.client">
+        <field name="name">Metabase Business Intelligence</field>
+        <field name="tag">metabase_iframe</field>
+        <field name="target">main</field>
+    </record>
+</odoo>

--- a/addons/metabase_integration/views/metabase_menu.xml
+++ b/addons/metabase_integration/views/metabase_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem id="menu_metabase_root"
+              name="Metabase Business Intelligence"
+              sequence="54"
+              action="action_metabase_iframe"/>
+</odoo>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,6 +221,18 @@ services:
     networks:
       - odoo-postiz-network
 
+  metabase:
+    image: metabase/metabase:latest
+    ports:
+      - "3030:3000"
+    environment:
+      MB_JETTY_PORT: 3000
+      JAVA_TIMEZONE: America/New_York
+    volumes:
+      - metabase-data:/metabase.db
+    networks:
+      - odoo-postiz-network
+
 volumes:
   odoo-db:
   postiz-db:
@@ -228,6 +240,7 @@ volumes:
   odoo-web:
   matomo-db:
   matomo-data:
+  metabase-data:
 
 networks:
   odoo-postiz-network:


### PR DESCRIPTION
## Summary
- add new Metabase integration module following Matomo pattern
- embed Metabase via iframe with OWL component
- expose `/metabase/config` route
- style Metabase iframe and menu entry
- run Metabase service in Docker Compose on port 3030

## Testing
- `python3 -m py_compile addons/metabase_integration/controllers/main.py`
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_6885488d0e18832cb5fb7f5503b53bc7