### PR TITLE
Fix Metabase embedding service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,7 +197,9 @@ services:
     environment:
       MB_JETTY_PORT: 3000
       JAVA_TIMEZONE: America/New_York
-      MB_EMBEDDING_APP_ORIGINS: http://localhost:8069
+      MB_ENABLE_EMBEDDING_STATIC: "true"
+      MB_EMBEDDING_SECRET_KEY: "ffffffffffffffffffffffffffffffff"
+      MB_SITE_URL: "http://localhost:3030"
     volumes:
       - metabase-data:/metabase.db
     networks:


### PR DESCRIPTION
## Summary
- update Metabase service configuration in docker compose

## Testing
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68857c8014c4832ca6e1c3fb10d35f05