### PR TITLE
Add metabase startup script and update compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,6 +202,8 @@ services:
       MB_SITE_URL: "http://localhost:3030"
     volumes:
       - metabase-data:/metabase.db
+      - ./metabase-init.sh:/metabase-init.sh
+    command: ["/bin/bash", "/metabase-init.sh"]
     networks:
       - odoo-postiz-network
 

--- a/metabase-init.sh
+++ b/metabase-init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export MB_ENABLE_EMBEDDING_STATIC=true
+export MB_EMBEDDING_SECRET_KEY=ffffffffffffffffffffffffffffffff
+java -jar /app/metabase.jar


### PR DESCRIPTION
## Summary
- add metabase-init.sh to set embedding env vars and run metabase jar
- mount the new script and use it as the metabase container command
- restore original environment variables for metabase service

## Testing
- ❌ `docker-compose config -q` *(failed: command not found)*
- ❌ `docker compose version` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688583c15474832c9f81a1f8d1d06973