### PR TITLE
Remove metabase init script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,8 +202,6 @@ services:
       MB_SITE_URL: "http://localhost:3030"
     volumes:
       - metabase-data:/metabase.db
-      - ./metabase-init.sh:/metabase-init.sh
-    command: ["/bin/bash", "/metabase-init.sh"]
     networks:
       - odoo-postiz-network
 

--- a/metabase-init.sh
+++ b/metabase-init.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-export MB_ENABLE_EMBEDDING_STATIC=true
-export MB_EMBEDDING_SECRET_KEY=ffffffffffffffffffffffffffffffff
-java -jar /app/metabase.jar


### PR DESCRIPTION
## Summary
- remove metabase init script
- update docker-compose to use default container entrypoint

## Testing
- `git show HEAD~1:metabase-init.sh | cat -n`


------
https://chatgpt.com/codex/tasks/task_e_68858be7877c832ca92d234d7f33f106