### PR TITLE
Enable Metabase iframe embedding

### DIFF
--- a/addons/metabase_integration/controllers/main.py
+++ b/addons/metabase_integration/controllers/main.py
@@ -9,7 +9,7 @@ class MetabaseController(http.Controller):
     def get_metabase_config(self):
         """Return Metabase configuration for the current user."""
         return {
-            'metabase_url': 'http://localhost:3030',
+            'metabase_url': 'http://localhost:3031',
             'user_name': request.env.user.name,
             'user_email': request.env.user.email,
             'user_id': request.env.user.id,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,6 +205,19 @@ services:
     networks:
       - odoo-postiz-network
 
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "3031:3031"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - web
+      - metabase
+    networks:
+      - odoo-postiz-network
+
 volumes:
   odoo-db:
   postiz-db:

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,11 +11,14 @@ http {
         server postiz:3000;
     }
     
+    upstream metabase {
+        server metabase:3000;
+    }
+    
     server {
         listen 80;
         server_name localhost;
         
-        # Odoo routes
         location / {
             proxy_pass http://odoo;
             proxy_set_header Host $host;
@@ -24,17 +27,23 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
         
-        # POSTIZ routes
         location /postiz/ {
             proxy_pass http://postiz/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            
-            # Allow iframe embedding
             proxy_hide_header X-Frame-Options;
             add_header X-Frame-Options "SAMEORIGIN" always;
+        }
+    }
+    
+    server {
+        listen 3031;
+        location / {
+            proxy_pass http://metabase;
+            proxy_hide_header X-Frame-Options;
+            proxy_hide_header Content-Security-Policy;
         }
     }
 }


### PR DESCRIPTION
## Summary
- proxy Metabase through nginx
- add nginx service to Docker Compose
- update Metabase configuration URL

## Testing
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688622dc2290832cb1b0f18784f34898