### PR TITLE
Update dittofeed service to lite version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,9 +205,9 @@ services:
     networks:
       - odoo-postiz-network
 
-  dittofeed:
-    image: dittofeed/dittofeed:latest
-    container_name: dittofeed
+  yamldittofeed:
+    image: dittofeed/dittofeed-lite:v0.22.0
+    container_name: yamldittofeed
     depends_on:
       - dittofeed-postgres
       - dittofeed-clickhouse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,9 +205,9 @@ services:
     networks:
       - odoo-postiz-network
 
-  yamldittofeed:
+  dittofeed:
     image: dittofeed/dittofeed-lite:v0.22.0
-    container_name: yamldittofeed
+    container_name: dittofeed
     depends_on:
       - dittofeed-postgres
       - dittofeed-clickhouse


### PR DESCRIPTION
## Summary
- rename `dittofeed` service to `yamldittofeed`
- use the `dittofeed/dittofeed-lite:v0.22.0` image

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68867a13a300832cb35dccdb3a9f0baf