### PR TITLE
Add BOOTSTRAP to dittofeed environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,6 +217,7 @@ services:
       AUTH_MODE: single-tenant
       WORKSPACE_NAME: DuxMachina
       DASHBOARD_API_BASE: http://localhost:3210
+      BOOTSTRAP: "false"
     volumes:
       - dittofeed-postgres:/var/lib/postgresql/data
       - dittofeed-clickhouse-data:/var/lib/clickhouse


### PR DESCRIPTION
## Summary
- add the `BOOTSTRAP` variable to the `dittofeed` service

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68868439c140832c8abd3455f1fed6ff